### PR TITLE
feat: Make command parameter optional for Docker and Command tasks

### DIFF
--- a/internal/core/models/task.go
+++ b/internal/core/models/task.go
@@ -38,16 +38,10 @@ type TaskConfig struct {
 func (c *TaskConfig) Validate(taskType TaskType) error {
 	switch taskType {
 	case TaskTypeDocker:
-		if len(c.Command) == 0 {
-			return errors.New("command is required for Docker tasks")
-		}
 		if c.ImageName == "" {
 			return errors.New("image name is required for Docker tasks")
 		}
 	case TaskTypeCommand:
-		if len(c.Command) == 0 {
-			return errors.New("command is required for Command tasks")
-		}
 	default:
 		return fmt.Errorf("unsupported task type: %s", taskType)
 	}

--- a/internal/execution/sandbox/docker/docker.go
+++ b/internal/execution/sandbox/docker/docker.go
@@ -122,6 +122,13 @@ func (e *DockerExecutor) ExecuteTask(ctx context.Context, task *models.Task) (*m
 		}
 	}
 
+	if len(config.Command) == 0 {
+		log.Debug().
+			Str("task_id", task.ID.String()).
+			Str("image", image).
+			Msg("No command specified, using default command from image")
+	}
+
 	containerID, err := e.containerMgr.CreateContainer(setupCtx, image, config.Command, workdir, envVars)
 	if err != nil {
 		log.Error().


### PR DESCRIPTION
This PR makes the `command` parameter optional for Docker and Command tasks. The changes include:

- Removed validation that required the `command` parameter for both Docker and Command task types
- Updated Docker container creation to use the image's default command/entrypoint when no command is provided
- Added logging to indicate when using the default command from an image

These changes allow for more flexibility when creating tasks, making it possible to rely on the default command/entrypoint defined in Docker images.

### Related PRs
This PR is in sync with [parity-server#34](https://github.com/theblitlabs/parity-server/pull/34) and should be merged alongside it.
