### PR TITLE
refactor: remove Command parameter from TaskConfig

### DIFF
--- a/internal/core/models/task.go
+++ b/internal/core/models/task.go
@@ -28,7 +28,6 @@ const (
 
 type TaskConfig struct {
 	FileURL        string            `json:"file_url,omitempty"`
-	Command        []string          `json:"command,omitempty"`
 	Env            map[string]string `json:"env,omitempty"`
 	Resources      ResourceConfig    `json:"resources,omitempty"`
 	DockerImageURL string            `json:"docker_image_url,omitempty"`

--- a/internal/execution/sandbox/docker/container.go
+++ b/internal/execution/sandbox/docker/container.go
@@ -144,7 +144,7 @@ func formatContainerOutput(output []byte) string {
 	return strings.TrimSpace(string(cleaned))
 }
 
-func (cm *ContainerManager) CreateContainer(ctx context.Context, image string, command []string, workdir string, envVars []string) (string, error) {
+func (cm *ContainerManager) CreateContainer(ctx context.Context, image string, workdir string, envVars []string) (string, error) {
 	log := gologger.WithComponent("docker.container")
 
 	createArgs := []string{
@@ -172,9 +172,6 @@ func (cm *ContainerManager) CreateContainer(ctx context.Context, image string, c
 	}
 
 	createArgs = append(createArgs, image)
-	if len(command) > 0 {
-		createArgs = append(createArgs, command...)
-	}
 
 	output, err := executils.ExecCommand(ctx, "docker", createArgs...)
 	if err != nil {

--- a/internal/execution/sandbox/docker/container.go
+++ b/internal/execution/sandbox/docker/container.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/theblitlabs/gologger"
+
 	"github.com/theblitlabs/parity-runner/internal/execution/sandbox/docker/executils"
 )
 
@@ -96,7 +97,7 @@ func writeSeccompProfileToTempFile() (string, error) {
 		return "", err
 	}
 
-	if err := os.WriteFile(seccompPath, profileData, 0600); err != nil {
+	if err := os.WriteFile(seccompPath, profileData, 0o600); err != nil {
 		log.Error().Err(err).Msg("Failed to write seccomp profile to temporary file")
 		return "", err
 	}

--- a/internal/execution/sandbox/docker/docker.go
+++ b/internal/execution/sandbox/docker/docker.go
@@ -191,7 +191,6 @@ func (e *DockerExecutor) ExecuteTask(ctx context.Context, task *models.Task) (*m
 			Str("task_id", task.ID.String()).
 			Str("container_id", containerID).
 			Msg("Security verification timed out, but continuing with execution")
-
 	} else if !isSecure || securityErr != nil {
 		log.Error().
 			Err(securityErr).

--- a/internal/execution/sandbox/docker/docker.go
+++ b/internal/execution/sandbox/docker/docker.go
@@ -94,7 +94,6 @@ func (e *DockerExecutor) ExecuteTask(ctx context.Context, task *models.Task) (*m
 	log.Info().
 		Str("task_id", task.ID.String()).
 		Str("image", image).
-		Strs("command", config.Command).
 		Msg("Task configuration loaded")
 
 	setupCtx, setupCancel := context.WithTimeout(ctx, e.config.Timeout)
@@ -135,19 +134,12 @@ func (e *DockerExecutor) ExecuteTask(ctx context.Context, task *models.Task) (*m
 		Strs("env_vars", envVars).
 		Msg("Container environment variables set")
 
-	if len(config.Command) == 0 {
-		log.Debug().
-			Str("task_id", task.ID.String()).
-			Str("image", image).
-			Msg("No command specified, using default command from image")
-	} else {
-		log.Debug().
-			Str("task_id", task.ID.String()).
-			Strs("command", config.Command).
-			Msg("Using specified command")
-	}
+	log.Debug().
+		Str("task_id", task.ID.String()).
+		Str("image", image).
+		Msg("Using default command from image")
 
-	containerID, err := e.containerMgr.CreateContainer(setupCtx, image, config.Command, workdir, envVars)
+	containerID, err := e.containerMgr.CreateContainer(setupCtx, image, workdir, envVars)
 	if err != nil {
 		log.Error().
 			Err(err).

--- a/internal/execution/sandbox/docker/image.go
+++ b/internal/execution/sandbox/docker/image.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/theblitlabs/gologger"
+
 	"github.com/theblitlabs/parity-runner/internal/execution/sandbox/docker/executils"
 )
 

--- a/internal/execution/sandbox/docker/seccomp_test.go
+++ b/internal/execution/sandbox/docker/seccomp_test.go
@@ -63,7 +63,6 @@ func TestContainerSecurityCheck(t *testing.T) {
 	containerID, err := cm.CreateContainer(
 		context.Background(),
 		"alpine:latest",
-		[]string{"sleep", "60"},
 		"/",
 		[]string{"TEST=true"},
 	)

--- a/internal/messaging/webhook/webhook.go
+++ b/internal/messaging/webhook/webhook.go
@@ -349,7 +349,7 @@ func (w *WebhookClient) handleWebhook(resp http.ResponseWriter, req *http.Reques
 
 func (w *WebhookClient) Register() error {
 	log := gologger.WithComponent("webhook")
-	
+
 	w.webhookURL = utils.GetWebhookURL()
 	log.Debug().Str("webhook_url", w.webhookURL).Msg("Generated webhook URL")
 

--- a/internal/server/runner_controller.go
+++ b/internal/server/runner_controller.go
@@ -89,8 +89,8 @@ func (c *RunnerController) handleHeartbeat(ctx *gin.Context) {
 	}
 
 	var msg struct {
-		Type    string          `json:"type"`
-		Payload gin.H           `json:"payload"`
+		Type    string `json:"type"`
+		Payload gin.H  `json:"payload"`
 	}
 
 	if err := ctx.BindJSON(&msg); err != nil {
@@ -143,6 +143,6 @@ func (c *RunnerController) handleTaskResult(ctx *gin.Context) {
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
 		return
 	}
-	
+
 	ctx.JSON(http.StatusOK, gin.H{"status": "ok"})
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -27,18 +27,18 @@ func NewServer(cfg *config.Config) *Server {
 	gin.SetMode(gin.ReleaseMode)
 
 	router := gin.New()
-	
+
 	router.Use(gin.Recovery())
-	
+
 	router.Use(func(c *gin.Context) {
 		start := time.Now()
 		path := c.Request.URL.Path
-		
+
 		c.Next()
-		
+
 		end := time.Now()
 		latency := end.Sub(start)
-		
+
 		log := gologger.WithComponent("gin")
 		log.Info().
 			Str("method", c.Request.Method).


### PR DESCRIPTION
This PR removes the Command parameter from the TaskConfig struct as it's no longer needed. The Docker executor now uses the default command from the Docker image instead of requiring a specific command to be provided.

### Changes Made
- Removed the `Command []string` field from the TaskConfig struct
- Updated the Docker executor to handle the absence of the Command parameter
- Modified the container manager's CreateContainer method to work with nil command parameter
- Fixed import formatting across affected files


Closes #42

### Related
- https://github.com/theblitlabs/parity-server/pull/37
