### PR TITLE
 feat: runner-side Hash Verification and Execution Integrity

### DIFF
--- a/internal/core/models/task_result.go
+++ b/internal/core/models/task_result.go
@@ -10,25 +10,28 @@ import (
 )
 
 type TaskResult struct {
-	ID              uuid.UUID `json:"id" gorm:"type:uuid;primaryKey"`
-	TaskID          uuid.UUID `json:"task_id" gorm:"type:uuid;index;not null;constraint:fk_task,onDelete:CASCADE"`
-	DeviceID        string    `json:"device_id" gorm:"type:varchar(255);not null"`
-	DeviceIDHash    string    `json:"device_id_hash" gorm:"type:varchar(64);not null"`
-	RunnerAddress   string    `json:"runner_address" gorm:"type:varchar(255);not null"`
-	CreatorAddress  string    `json:"creator_address" gorm:"type:varchar(255);not null"`
-	Output          string    `json:"output" gorm:"type:text"`
-	Error           string    `json:"error,omitempty" gorm:"type:text"`
-	ExitCode        int       `json:"exit_code" gorm:"type:int"`
-	ExecutionTime   int64     `json:"execution_time" gorm:"type:bigint"`
-	CreatedAt       time.Time `json:"created_at" gorm:"type:timestamp with time zone;default:now()"`
-	CreatorDeviceID string    `json:"creator_device_id" gorm:"type:text"`
-	SolverDeviceID  string    `json:"solver_device_id" gorm:"type:text"`
-	Reward          float64   `json:"reward" gorm:"type:decimal(20,8)"`
-	CPUSeconds      float64   `json:"cpu_seconds" gorm:"type:decimal(20,8);default:0"`
-	EstimatedCycles uint64    `json:"estimated_cycles" gorm:"type:bigint;not null;default:0"`
-	MemoryGBHours   float64   `json:"memory_gb_hours" gorm:"type:decimal(20,8);default:0"`
-	StorageGB       float64   `json:"storage_gb" gorm:"type:decimal(20,8);default:0"`
-	NetworkDataGB   float64   `json:"network_data_gb" gorm:"type:decimal(20,8);default:0"`
+	ID                  uuid.UUID `json:"id" gorm:"type:uuid;primaryKey"`
+	TaskID              uuid.UUID `json:"task_id" gorm:"type:uuid;index;not null;constraint:fk_task,onDelete:CASCADE"`
+	DeviceID            string    `json:"device_id" gorm:"type:varchar(255);not null"`
+	DeviceIDHash        string    `json:"device_id_hash" gorm:"type:varchar(64);not null"`
+	RunnerAddress       string    `json:"runner_address" gorm:"type:varchar(255);not null"`
+	CreatorAddress      string    `json:"creator_address" gorm:"type:varchar(255);not null"`
+	Output              string    `json:"output" gorm:"type:text"`
+	Error               string    `json:"error,omitempty" gorm:"type:text"`
+	ExitCode            int       `json:"exit_code" gorm:"type:int"`
+	ExecutionTime       int64     `json:"execution_time" gorm:"type:bigint"`
+	ResultHash          string    `json:"result_hash" gorm:"type:varchar(64)"`
+	ImageHashVerified   string    `json:"image_hash_verified" gorm:"type:varchar(64)"`
+	CommandHashVerified string    `json:"command_hash_verified" gorm:"type:varchar(64)"`
+	CreatedAt           time.Time `json:"created_at" gorm:"type:timestamp with time zone;default:now()"`
+	CreatorDeviceID     string    `json:"creator_device_id" gorm:"type:text"`
+	SolverDeviceID      string    `json:"solver_device_id" gorm:"type:text"`
+	Reward              float64   `json:"reward" gorm:"type:decimal(20,8)"`
+	CPUSeconds          float64   `json:"cpu_seconds" gorm:"type:decimal(20,8);default:0"`
+	EstimatedCycles     uint64    `json:"estimated_cycles" gorm:"type:bigint;not null;default:0"`
+	MemoryGBHours       float64   `json:"memory_gb_hours" gorm:"type:decimal(20,8);default:0"`
+	StorageGB           float64   `json:"storage_gb" gorm:"type:decimal(20,8);default:0"`
+	NetworkDataGB       float64   `json:"network_data_gb" gorm:"type:decimal(20,8);default:0"`
 }
 
 func (r *TaskResult) Clean() {

--- a/internal/runner/verification.go
+++ b/internal/runner/verification.go
@@ -1,0 +1,89 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/theblitlabs/gologger"
+
+	"github.com/theblitlabs/parity-runner/internal/core/models"
+)
+
+type VerificationData struct {
+	TaskID              string `json:"task_id"`
+	RunnerID            string `json:"runner_id"`
+	ImageHashVerified   string `json:"image_hash_verified"`
+	CommandHashVerified string `json:"command_hash_verified"`
+	Timestamp           int64  `json:"timestamp"`
+}
+
+type VerificationService struct {
+	serverURL string
+	client    *http.Client
+}
+
+func NewVerificationService(serverURL string) *VerificationService {
+	return &VerificationService{
+		serverURL: serverURL,
+		client: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+func (v *VerificationService) SendHashVerification(ctx context.Context, task *models.Task, result *models.TaskResult, runnerID string) error {
+	log := gologger.WithComponent("verification")
+
+	verificationData := VerificationData{
+		TaskID:              task.ID.String(),
+		RunnerID:            runnerID,
+		ImageHashVerified:   result.ImageHashVerified,
+		CommandHashVerified: result.CommandHashVerified,
+		Timestamp:           time.Now().Unix(),
+	}
+
+	jsonData, err := json.Marshal(verificationData)
+	if err != nil {
+		return fmt.Errorf("failed to marshal verification data: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/api/v1/tasks/%s/verify-hashes", v.serverURL, task.ID.String())
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("failed to create verification request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Runner-ID", runnerID)
+
+	resp, err := v.client.Do(req)
+	if err != nil {
+		log.Error().
+			Err(err).
+			Str("task_id", task.ID.String()).
+			Str("runner_id", runnerID).
+			Msg("Failed to send hash verification to server")
+		return fmt.Errorf("failed to send verification request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		log.Error().
+			Int("status_code", resp.StatusCode).
+			Str("task_id", task.ID.String()).
+			Str("runner_id", runnerID).
+			Msg("Server rejected hash verification")
+		return fmt.Errorf("server rejected verification: status %d", resp.StatusCode)
+	}
+
+	log.Info().
+		Str("task_id", task.ID.String()).
+		Str("runner_id", runnerID).
+		Msg("Hash verification sent successfully")
+
+	return nil
+}

--- a/internal/utils/hash.go
+++ b/internal/utils/hash.go
@@ -1,0 +1,57 @@
+package utils
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+func VerifyImageHash(imageName string) (string, error) {
+	cmd := exec.Command("docker", "image", "inspect", "--format={{.Id}}", imageName)
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to inspect image: %w", err)
+	}
+
+	imageID := strings.TrimSpace(string(output))
+	if strings.HasPrefix(imageID, "sha256:") {
+		imageID = imageID[7:]
+	}
+
+	return imageID, nil
+}
+
+func ComputeCommandHash(command []string) string {
+	commandStr := strings.Join(command, " ")
+	hash := sha256.Sum256([]byte(commandStr))
+	return fmt.Sprintf("%x", hash)
+}
+
+func ComputeResultHash(stdout, stderr string, exitCode int) string {
+	combined := fmt.Sprintf("%s%s%d", stdout, stderr, exitCode)
+	hash := sha256.Sum256([]byte(combined))
+	return fmt.Sprintf("%x", hash)
+}
+
+func LoadAndVerifyImage(imagePath string) (string, error) {
+	cmd := exec.Command("docker", "load", "-i", imagePath)
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to load image: %w", err)
+	}
+
+	outputStr := string(output)
+	lines := strings.Split(outputStr, "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "Loaded image:") {
+			parts := strings.Split(line, ":")
+			if len(parts) >= 2 {
+				imageName := strings.TrimSpace(strings.Join(parts[1:], ":"))
+				return imageName, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("could not determine loaded image name")
+}


### PR DESCRIPTION
# Implements runner-side hash verification and execution integrity monitoring for the Parity Protocol.

## Changes
- Add hash verification utilities for image and command validation
- Extend task result model to include hash verification fields
- Integrate hash verification into docker execution workflow
- Add verification service for communicating hash data to server
- Support docker image hash verification using docker inspect
- Compute and validate result hashes for consensus verification

## Related PRs
- **Client-side implementation**: 
- **Server-side implementation**:

## Closes
- https://github.com/theblitlabs/parity-runner/issues/29

## Testing
- [x] Pre-commit checks pass
- [x] Hash verification integrated into execution
- [x] Import formatting corrected